### PR TITLE
restrict concurrent access to api

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+Version 0.7.3
+~~~~~~~~~~~~~
+
+* Updated BaseService to accept a custom AuthenticatorPlugin class.
+
 Version 0.7.2
 ~~~~~~~~~~~~~
 

--- a/stamps/__init__.py
+++ b/stamps/__init__.py
@@ -11,4 +11,4 @@
 
 __author__ = "Jonathan Zempel"
 __license__ = "BSD"
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/stamps/services.py
+++ b/stamps/services.py
@@ -80,16 +80,25 @@ class BaseService(object):
     """Base service.
 
     :param configuration: API configuration.
+    :param authenticator_plugin_class: Default :class:`AuthenticatorPlugin`.
     """
 
-    def __init__(self, configuration):
+    def __init__(self, configuration,
+            authenticator_plugin_class=AuthenticatorPlugin):
         Factory.maptag("decimal", XDecimal)
         self.client = Client(configuration.wsdl)
         credentials = self.create("Credentials")
         credentials.IntegrationID = configuration.integration_id
         credentials.Username = configuration.username
         credentials.Password = configuration.password
-        self.plugin = AuthenticatorPlugin(credentials, self.client)
+
+        if issubclass(authenticator_plugin_class, AuthenticatorPlugin):
+            self.plugin = authenticator_plugin_class(credentials, self.client)
+        else:
+            message = "{0} is not a subclass of {1}.".format(
+                authenticator_plugin_class, AuthenticatorPlugin)
+            raise TypeError(message)
+
         self.client.set_options(plugins=[self.plugin], port=configuration.port)
         self.logger = getLogger("stamps")
 

--- a/stamps/tests.py
+++ b/stamps/tests.py
@@ -10,7 +10,7 @@
 """
 
 from .config import StampsConfiguration
-from .services import StampsService
+from .services import AuthenticatorPlugin, StampsService
 from datetime import date, datetime
 from time import sleep
 from unittest import TestCase
@@ -147,3 +147,17 @@ class StampsTestCase(TestCase):
         self.service.plugin.authenticator = authenticator
         result = self.service.get_account()
         print result
+
+    def test_4(self):
+        """Test custom authenticator plugin.
+        """
+        class InvalidAuthenticatorPlugin(object):
+            pass
+
+        with self.assertRaises(TypeError):
+            StampsService(CONFIGURATION, InvalidAuthenticatorPlugin)
+
+        class ValidAuthenticatorPlugin(AuthenticatorPlugin):
+            pass
+
+        StampsService(CONFIGURATION, ValidAuthenticatorPlugin)


### PR DESCRIPTION
I am running into an issue of having lots of "Invalid Conversation Token" and "Conversation Out-of-Sync" due to concurrent usage.

Typically, this eventually works out with retries but would be much more expedient/efficient to restrict concurrent access to the api with a locking mechanism.

I am using django so I am leaning towards a fast implementation by storing totals and authenticators in a database with the django orm, using cache locks, and letting retries work out the kinks that accompany possible lock evictions with a cache backend.

Is concurrent access restriction out of the scope of this project?

