### PR TITLE
use pip installable "suds-jurko" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     packages=["stamps"],
     package_data={"stamps": ["wsdls/*.wsdl"]},
     include_package_data=True,
-    install_requires=["suds==0.4.1"],
-    dependency_links=["https://github.com/nemith/suds/tarball/master#egg=suds-0.4.1"],  # NOQA
+    install_requires=["suds-jurko"],
     test_suite="stamps.tests"
 )


### PR DESCRIPTION
I've tried the suds-jurko package out and am not observing any issues.  It appears to have stabilized enough to be a drop in replacement as far as this project is concerned.  I've used it on a Windows 8.1 dev machine using Python 2.7.10

Pip currently installs "suds-jurko==0.7.dev0".  I don't think it is necessary to specify a specific version in the setup.py file at this point.