### PR TITLE
Rates response can be set to empty string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+Version 0.9.1
+^^^^^^^^^^^^^
+
+* Validate `get_rates` service response.
+
 Version 0.9
 ^^^^^^^^^^^
 

--- a/stamps/__init__.py
+++ b/stamps/__init__.py
@@ -11,4 +11,4 @@
 
 __author__ = "Jonathan Zempel"
 __license__ = "BSD"
-__version__ = "0.9"
+__version__ = "0.9.1"

--- a/stamps/services.py
+++ b/stamps/services.py
@@ -230,7 +230,12 @@ class StampsService(BaseService):
         """
         rates = self.call("GetRates", Rate=shipping)
 
-        return [rate for rate in rates.Rates.Rate]
+        if rates.Rates:
+            ret_val = [rate for rate in rates.Rates.Rate]
+        else:
+            ret_val = []
+
+        return ret_val
 
     def get_tracking(self, transaction_id):
         """Get tracking events for a shipment.


### PR DESCRIPTION
Just hit an issue where [rates.Rates](https://github.com/jzempel/stamps/blob/master/stamps/services.py#L233) was an empty string.  Case should be handled so the service get_rates() method does not throw an exception and instead returns an empty list